### PR TITLE
Update the mining pools list

### DIFF
--- a/src/getting-started/mining-pools.md
+++ b/src/getting-started/mining-pools.md
@@ -8,7 +8,7 @@ A list of known pools for Arionum.
 - [AroPool](https://aropool.com) (HTTPS/HTTP) `5% fee`
 - [ARO.Cool](https://aro.cool) (HTTPS/HTTP) `2% fee`
 - [Arionum Rocks](http://arionum.rocks) (HTTP only) `No fee`
-- [Aro Pool EU](https://aropool.eu) (HTTPS/HTTP) `2% fee`
+- [ArioPool](https://pool.ariochain.info) (HTTPS/HTTP) `2.75% fee`
 
 ## Solo Pools
 

--- a/src/getting-started/mining-pools.md
+++ b/src/getting-started/mining-pools.md
@@ -7,9 +7,4 @@ A list of known pools for Arionum.
 - [ArionumPool](https://arionumpool.com) (HTTPS/HTTP) `1% fee`
 - [AroPool](https://aropool.com) (HTTPS/HTTP) `5% fee`
 - [ARO.Cool](https://aro.cool) (HTTPS/HTTP) `2% fee`
-- [Arionum Rocks](http://arionum.rocks) (HTTP only) `No fee`
 - [ArioPool](https://pool.ariochain.info) (HTTPS/HTTP) `2.75% fee`
-
-## Solo Pools
-
-- [ARO.HashPi](https://aro.hashpi.com) (HTTPS) `1% fee`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds ArioPool instead of Aro Pool EU, and removes Arionum.Rocks and Aro.HashPi which are no longer available.

## Types of changes

Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
